### PR TITLE
Fix mis-spelling of 'repository' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-plugin-antd",
   "version": "1.0.12",
   "description": "Gatsby plugin to use Ant Design",
-  "respository": {
+  "repository": {
   	"type": "git",
   	"url": "https://github.com/bskimball/gatsby-plugin-antd"
   },


### PR DESCRIPTION
Gatsby uses the repository field to display information about the plugin in its plugin library and is failing because it wasn't spelt correctly: https://www.gatsbyjs.org/packages/gatsby-plugin-antd/ Also see issue: https://github.com/gatsbyjs/gatsby/issues/5541