### PR TITLE
Update config to match gatsbyjs v2 api

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,11 +1,9 @@
-exports.modifyBabelrc = ( {babelrc}, {style} ) => {
-  return {
-    ...babelrc,
-    plugins: babelrc.plugins.concat([
-      ['import', {
-        libraryName: 'antd',
-        style: (style) ? style : 'css'
-      }]
-    ])
-  }
-}
+exports.onCreateBabelConfig = ({ actions }) => {
+  actions.setBabelPlugin({
+      name: `babel-plugin-import`,
+      options: {
+          libraryName: "antd",
+          style: "css",
+      },
+  });
+};


### PR DESCRIPTION
Just doing a pull request for heads up on upgrading the config for v2. Not sure how you want to separate your versions however.

GatsbyJs2 doc reference for new API:
https://next.gatsbyjs.org/docs/node-apis/#onCreateBabelConfig

Github issue:
https://github.com/gatsbyjs/gatsby/issues/3969

